### PR TITLE
add avatar icon and convert name for hubot

### DIFF
--- a/src/devhub.coffee
+++ b/src/devhub.coffee
@@ -14,6 +14,8 @@ class Devhub extends Adapter
     @bot = new DevhubStreaming options, @robot
 
     @bot.on 'message', (userId, message) =>
+      name_re = new RegExp("^[ ]*@" + options.name + "さん");
+      message = message.replace(name_re, options.name)
       user = @robot.brain.userForId userId
       @receive new TextMessage user, message
 
@@ -31,9 +33,9 @@ class DevhubStreaming extends EventEmitter
 
 
   send: (message) ->
-    @socket.emit "message", {name:@name, msg:message}
+    @socket.emit "message", {name:@name, msg:message, avatar:"img/hubot.png" }
 
   listen: ->
     @socket.on "message", (item)=>
       @emit 'message', item.name, item.msg
-    @socket.emit 'name', {name:@name}
+    @socket.emit 'name', {name:@name, avatar:"img/hubot.png"}


### PR DESCRIPTION
Hubot 用のアバター画像に対応してみました。
画像本体は悩みましたが devhub の static/img/hubot.png として入れちゃいました。
(なので devhub本体との同期が必要になっちゃってます)
あと、@hubotさん xxxx で話しかけても反応してもらえるように変換処理も追加しました。
