### PR TITLE
Split "keywords" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
     "name": "hashrock"
   },
   "keywords": [
-    "github hubot DevHub adapter"
+    "github",
+    "hubot",
+    "DevHub",
+    "adapter"
   ],
   "description": "An DevHub adapter for hubot",
   "licenses": [


### PR DESCRIPTION
npm の package.json の規約に沿って "keywords" を配列にしました。
ちなみに、こうしておくと [npmjs.org](https://www.npmjs.org/package/hubot-devhub) でキーワードごとにリンクが設定されるので、関連するモジュールを探しやすくなります。

see: https://www.npmjs.org/doc/files/package.json.html#keywords

> Put keywords in it. It's an array of strings. 
