### PR TITLE
update socket.io-client in order to maintain the devhub v2.0 compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
   },
   "homepage": "https://github.com/hashrock/hubot-devhub",
   "dependencies": {
-    "socket.io-client": "^0.9.9"
+    "socket.io-client": "1.4.5"
   }
 }


### PR DESCRIPTION
DevHub v2.0 で socket.io をバージョンを 1.4.5 としたので
hubot の socket.io-client も互換性のある 1.4.5 にアップデートしました。
